### PR TITLE
fix: improve sign out button hover contrast and smoothness in light mode

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -644,12 +644,13 @@ const STYLES = `
     border-radius: 2px;
     padding: 4px 10px;
     cursor: pointer;
-    transition: color 0.15s, border-color 0.15s;
+    transition: color 0.2s ease, border-color 0.2s ease, background 0.2s ease;
   }
 
   .btn-logout:hover {
-    color: var(--text);
-    border-color: var(--border);
+    color: var(--bg);
+    background: var(--text);
+    border-color: var(--text);
   }
 
   /* Theme toggle button */


### PR DESCRIPTION
Fill the button with `var(--text)` (#1a1a1a) on hover and switch text to `var(--bg)` for high contrast, with smooth 0.2s ease transitions on all properties.

Closes #1

Generated with [Claude Code](https://claude.ai/code)